### PR TITLE
add JSON.stringify whitespace argument and tests

### DIFF
--- a/__tests__/logger.test.ts
+++ b/__tests__/logger.test.ts
@@ -262,3 +262,25 @@ describe('trace', () => {
     expect(consoleSpy).toBeCalledWith(expectedLogs[2])
   })
 })
+describe('JSON format', () => {
+  it('JSON.stringify should be called with 2 spaces', () => {
+    const logger = new Logger({
+      level: 'INFO',
+      numSpaces: 2,
+    })
+    logger.info({ field1: 1, field2: 2 })
+    expect(consoleSpy).toBeCalledWith(
+      JSON.stringify({ severity: 'INFO', field1: 1, field2: 2 }, null, 2),
+    )
+  })
+  it('JSON.stringify should be called with 4 spaces', () => {
+    const logger = new Logger({
+      level: 'INFO',
+      numSpaces: 4,
+    })
+    logger.info({ field1: 1, field2: 2 })
+    expect(consoleSpy).toBeCalledWith(
+      JSON.stringify({ severity: 'INFO', field1: 1, field2: 2 }, null, 4),
+    )
+  })
+})

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -25,9 +25,11 @@ const addRequestTrace = (
 export class Logger {
   private level: number
   private additionalEntries?: Record<string, any>
+  private numSpaces?: number
 
   constructor(args: {
     level: Level | number
+    numSpaces?: number
     traceOptions?: {
       request: Request
       gcpProject: string
@@ -53,6 +55,7 @@ export class Logger {
       additionalEntries = args.additionalEntries
     }
     this.additionalEntries = additionalEntries
+    this.numSpaces = args.numSpaces
   }
 
   public error(args: { error?: Error; entries?: Record<string, any> }): void {
@@ -92,6 +95,6 @@ export class Logger {
       ...args.entries,
       ...this.additionalEntries,
     }
-    console.log(JSON.stringify(log))
+    console.log(JSON.stringify(log, undefined, this.numSpaces))
   }
 }


### PR DESCRIPTION
logge-loggelito is clearly the best logging solution in the history of software. That being said, I believe improvements can be made. This one will only bring logge further ahead in the game and finally deprecate the competition.